### PR TITLE
Issue 38: Fix failed test due to CPython str/enum behavior change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,14 +3,18 @@ on: [push, pull_request]
 jobs:
   run:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.10
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |

--- a/src/rfbzero/experiment.py
+++ b/src/rfbzero/experiment.py
@@ -638,7 +638,7 @@ class CyclingProtocol(ABC):
     @staticmethod
     def _end_protocol(results: CyclingResults, end_status: CyclingStatus) -> CyclingResults:
         """Records the status that ended the simulation and logs the time."""
-        print(f'Simulation stopped after {results.steps} time steps: {end_status}.')
+        print(f'Simulation stopped after {results.steps} time steps: {end_status.value}.')
         results.end_status = end_status
         results._finalize()
         return results
@@ -738,7 +738,7 @@ class ConstantCurrent(CyclingProtocol):
                 raise ValueError(cycling_status)
 
             cycle_name = 'charge' if self.charge_first else 'discharge'
-            print(f'Skipping to {cycle_name} cycle: {cycling_status}')
+            print(f'Skipping to {cycle_name} cycle: {cycling_status.value}')
             cycling_status = CyclingStatus.NORMAL
 
         while cycling_status == CyclingStatus.NORMAL:
@@ -983,7 +983,7 @@ class ConstantCurrentConstantVoltage(CyclingProtocol):
         cycling_status = cycle_mode.validate()
         is_cc_mode = cycling_status == CyclingStatus.NORMAL
         if not is_cc_mode:
-            print(f'Skipping to CV cycling: {cycling_status}')
+            print(f'Skipping to CV cycling: {cycling_status.value}')
             cv_current = self.current_charge if self.charge_first else self.current_discharge
             cycle_mode = get_cv_cycle_mode(self.charge_first, cv_current)
             cycling_status = cycle_mode.validate()


### PR DESCRIPTION
Fixes a test failure that was due to the `CyclingStatus` end status of an experiment being printed as the enum name (i.e. `CyclingStatus.LOW_CAPACITY`) instead of the enum's string value (i.e. `capacity is less than 1% of initial CLS capacity`).

This failure is due to a behavior change between versions `3.10` and `3.11` of CPython, where the `__format__` behavior of a class inheriting both `str` and `Enum` was changed (from returning the enum value to returning the enum name in `3.11`+). See [this CPython issue](https://github.com/python/cpython/issues/100458) for further details.

This PR also updates the GitHub actions to run the tests using multiple versions of Python. Previously, only `3.10` was tested which is why this failure was not encountered on previous PRs.

This addresses https://github.com/ericfell/rfbzero/issues/38, and relates to https://github.com/openjournals/joss-reviews/issues/6537.